### PR TITLE
Point to Github instead of to a broken redirect

### DIFF
--- a/options.js
+++ b/options.js
@@ -183,7 +183,7 @@ var initializeServicesList = function() {
     $(document.createTextNode("("))
       .appendTo(span);
     $("<a>")
-      .attr("href", "https://code.google.com/p/mailto-chromeextension/wiki/AddCustomUrl")
+      .attr("href", "https://github.com/Famlam/mailto-chromeextension/blob/master/docs/AddCustomUrl.md")
       .attr("target", "_blank")
       .attr("title", chrome.i18n.getMessage("getHelpTitle"))
       .text(chrome.i18n.getMessage("getHelp"))


### PR DESCRIPTION
Send user to the [Github help doc](https://github.com/Famlam/mailto-chromeextension/blob/master/docs/AddCustomUrl.md) instead of to a defunct [Google Code](https://code.google.com/p/mailto-chromeextension/wiki/AddCustomUrl) page (which redirects to this project’s Github page).

There’s also a [proposed change to options.html](https://github.com/Famlam/mailto-chromeextension/compare/master...LucasLarson:patch-2), which is ready for merge.